### PR TITLE
numerical stability for 1 bit quantization

### DIFF
--- a/learners/nonuniform_quantization/utils.py
+++ b/learners/nonuniform_quantization/utils.py
@@ -405,8 +405,9 @@ class NonUniformQuantization:
 
     w_max = tf.stop_gradient(tf.reduce_max(w, axis=axis))
     w_min = tf.stop_gradient(tf.reduce_min(w, axis=axis))
-
-    alpha = w_max - w_min
+    eps = tf.constant(value=1e-10, dtype=tf.float32)
+    
+    alpha = w_max - w_min + eps
     beta = w_min
     w = (w - beta) / alpha
     return w, alpha, beta

--- a/learners/uniform_quantization/utils.py
+++ b/learners/uniform_quantization/utils.py
@@ -223,8 +223,9 @@ class UniformQuantization:
 
     w_max = tf.stop_gradient(tf.reduce_max(w, axis=axis))
     w_min = tf.stop_gradient(tf.reduce_min(w, axis=axis))
-
-    alpha = w_max - w_min
+    eps = tf.constant(value=1e-10, dtype=tf.float32)
+    
+    alpha = w_max - w_min + eps
     beta = w_min
     w = (w - beta) / alpha
     return w, alpha, beta


### PR DESCRIPTION
Closes #73 

This fix is generally helpful. In case a variable in customized model contains only a few values, chances are that the max value equals to (or very close to) its min value, causing a NaN problem.