### PR TITLE
Fix for using single GPU in local mode; Change of definition of idle GPU

### DIFF
--- a/utils/get_idle_gpus.py
+++ b/utils/get_idle_gpus.py
@@ -39,8 +39,8 @@ idle_gpus = []
 
 for gpu in gpuSmiOutput.split(sep='\n')[:-1]:
     (gpuId, used, total) = [int(value) for value in gpu.split(sep=',')]
-    usagePercentage = (used/total)
-    if usagePercentage < maxGpuUsageThreshold:
+    memoryUsagePercentage = (used/total)
+    if memoryUsagePercentage < maxGpuUsageThreshold:
         # GPU usage is less than the threshold
         idle_gpus.append(gpuId)
 

--- a/utils/get_idle_gpus.py
+++ b/utils/get_idle_gpus.py
@@ -25,28 +25,28 @@ assert len(sys.argv) == 2
 nb_idle_gpus = int(sys.argv[1])
 
 # assume: idle gpu has no more than 50% of total card memory used
-maxGpuUsageThreshold = .5
+max_gpu_usage_threshold = .5
 
 # command to execute to get gpu id and corresponding memory used
 # and total memory. It gives output in the format
 # gpu id, memory used, total memory
 cmd = 'nvidia-smi --query-gpu=index,memory.used,memory.total ' \
-    '--format=csv,noheader,nounits'
-gpuSmiOutput = subprocess.check_output(cmd, shell=True)
-gpuSmiOutput = gpuSmiOutput.decode('utf-8')
+  '--format=csv,noheader,nounits'
+gpu_smi_output = subprocess.check_output(cmd, shell=True)
+gpu_smi_output = gpu_smi_output.decode('utf-8')
 
 idle_gpus = []
 
-for gpu in gpuSmiOutput.split(sep='\n')[:-1]:
-    (gpuId, used, total) = [int(value) for value in gpu.split(sep=',')]
-    memoryUsagePercentage = (used/total)
-    if memoryUsagePercentage < maxGpuUsageThreshold:
-        # GPU usage is less than the threshold
-        idle_gpus.append(gpuId)
+for gpu in gpu_smi_output.split(sep='\n')[:-1]:
+  (gpu_id, used, total) = [int(value) for value in gpu.split(sep=',')]
+  memory_usage_percentage = (used/total)
+  if memory_usage_percentage < max_gpu_usage_threshold:
+    # GPU usage is less than the threshold
+    idle_gpus.append(gpu_id)
 
 if len(idle_gpus) < nb_idle_gpus:
-    raise ValueError('not enough idle GPUs;'
-                     ' idle GPUs are: {}'.format(idle_gpus))
+  raise ValueError('not enough idle GPUs;'
+                   ' idle GPUs are: {}'.format(idle_gpus))
 idle_gpus = idle_gpus[:nb_idle_gpus]
 idle_gpus_str = ','.join([str(idle_gpu) for idle_gpu in idle_gpus])
 print(idle_gpus_str)

--- a/utils/get_idle_gpus.py
+++ b/utils/get_idle_gpus.py
@@ -24,37 +24,29 @@ import subprocess
 assert len(sys.argv) == 2
 nb_idle_gpus = int(sys.argv[1])
 
-# dump the output of "nvidia-smi" command to file
-dump_file = './nvidia-smi-dump'
-with open(dump_file, 'w') as o_file:
-  subprocess.call(['nvidia-smi'], stdout=o_file)
+# assume: idle gpu has no more than 50% of total card memory used
+maxGpuUsageThreshold = .5
 
-# parse the output of "nvidia-smi" command
-with open(dump_file, 'r') as i_file:
-  # obtain list of all & busy GPUs
-  parse_procs = False
-  all_gpus, busy_gpus = [], []
-  for i_line in i_file:
-    if 'Processes' in i_line:
-      parse_procs = True
-    sub_strs = i_line.split()
-    if len(sub_strs) < 2:
-      continue
-    if not parse_procs:
-      if sub_strs[1].isdigit():
-        all_gpus.append(sub_strs[1])
-    else:
-      if sub_strs[1].isdigit():
-        busy_gpus.append(sub_strs[1])
+# command to execute to get gpu id and corresponding memory used
+# and total memory. It gives output in the format
+# gpu id, memory used, total memory
+cmd = 'nvidia-smi --query-gpu=index,memory.used,memory.total ' \
+    '--format=csv,noheader,nounits'
+gpuSmiOutput = subprocess.check_output(cmd, shell=True)
+gpuSmiOutput = gpuSmiOutput.decode('utf-8')
 
-  # obtain list of idle GPUs
-  idle_gpus = list(set(all_gpus) - set(busy_gpus))
-  idle_gpus.sort()
-  if len(idle_gpus) < nb_idle_gpus:
-    raise ValueError('not enough idle GPUs; idle GPUs are: {}'.format(idle_gpus))
-  idle_gpus = idle_gpus[:nb_idle_gpus]
-  idle_gpus_str = ','.join([str(idle_gpu) for idle_gpu in idle_gpus])
-  print(idle_gpus_str)
+idle_gpus = []
 
-# remove the dump file
-os.remove(dump_file)
+for gpu in gpuSmiOutput.split(sep='\n')[:-1]:
+    (gpuId, used, total) = [int(value) for value in gpu.split(sep=',')]
+    usagePercentage = (used/total)
+    if usagePercentage < maxGpuUsageThreshold:
+        # GPU usage is less than the threshold
+        idle_gpus.append(gpuId)
+
+if len(idle_gpus) < nb_idle_gpus:
+    raise ValueError('not enough idle GPUs;'
+                     ' idle GPUs are: {}'.format(idle_gpus))
+idle_gpus = idle_gpus[:nb_idle_gpus]
+idle_gpus_str = ','.join([str(idle_gpu) for idle_gpu in idle_gpus])
+print(idle_gpus_str)


### PR DESCRIPTION
The PR would allow PocketFlow to be used with a single GPU in local mode.
Previously we were calculating idle GPU as a GPU with no processes running
on it. This is not the case if there's a single GPU since a portion of GPU's
capability is used for display.
We now calculate idle GPU as GPU with no more than 50% of its memory used.
The policy is as discussed at #34.

The PR fixes #34 and #29.

Note: We are now not creating the dump file, but instead storing the output 
of commands in a variable and processing it.

Testing:
Tested it by performing `DisChnPrunedLearner` on resnet-20 with CIFAR-10 dataset .