### PR TITLE
fix Shape Error #76

### DIFF
--- a/learners/nonuniform_quantization/bit_optimizer.py
+++ b/learners/nonuniform_quantization/bit_optimizer.py
@@ -278,7 +278,8 @@ class BitOptimizer(object):
   def __global_finetune(self, feed_dict_train):
     time_prev = timer()
     for t_step in range(self.tune_global_steps):
-      _ = self.sess_train.run(self.ops['train'], feed_dict=feed_dict_train)
+      # _ = self.sess_train.run(self.ops['train'], feed_dict=feed_dict_train)
+      _ = self.sess_train.run(self.ops['rl_fintune'], feed_dict=feed_dict_train)
       if (t_step+1) % self.tune_global_disp_steps == 0:
         log_rslt = self.sess_train.run(self.ops['log'], feed_dict=feed_dict_train)
         time_prev = self.__monitor_progress(t_step, log_rslt, time_prev)

--- a/learners/nonuniform_quantization/bit_optimizer.py
+++ b/learners/nonuniform_quantization/bit_optimizer.py
@@ -278,8 +278,7 @@ class BitOptimizer(object):
   def __global_finetune(self, feed_dict_train):
     time_prev = timer()
     for t_step in range(self.tune_global_steps):
-      # _ = self.sess_train.run(self.ops['train'], feed_dict=feed_dict_train)
-      _ = self.sess_train.run(self.ops['rl_fintune'], feed_dict=feed_dict_train)
+      self.sess_train.run(self.ops['rl_fintune'], feed_dict=feed_dict_train)
       if (t_step+1) % self.tune_global_disp_steps == 0:
         log_rslt = self.sess_train.run(self.ops['log'], feed_dict=feed_dict_train)
         time_prev = self.__monitor_progress(t_step, log_rslt, time_prev)

--- a/learners/nonuniform_quantization/learner.py
+++ b/learners/nonuniform_quantization/learner.py
@@ -279,7 +279,7 @@ class NonUniformQuantLearner(AbstractLearner):
       # define the ops
       with tf.control_dependencies(self.update_ops):
         self.ops['train'] = optimizer.apply_gradients(grads, global_step=self.ft_step)
-        if FLAGS.nuql_opt_mode != 'weights' and FLAGS.nuql_enbl_rl_agent == True:
+        if FLAGS.nuql_opt_mode in ['both', 'cluster'] and FLAGS.nuql_enbl_rl_agent:
           self.ops['rl_fintune'] = optimizer_fintune.apply_gradients(grads_fintune, global_step=self.ft_step)
         else:
           self.ops['rl_fintune'] = self.ops['train']

--- a/learners/nonuniform_quantization/learner.py
+++ b/learners/nonuniform_quantization/learner.py
@@ -255,19 +255,15 @@ class NonUniformQuantLearner(AbstractLearner):
           if v not in clusters]
 
       # determine the var_list optimize
-      # Temperally use GradientDescentOptimizer for fintune in during rl-rollouts. This fixes issue #76. 
-      # However, this will make the fintuning result during rl-rollouts based on GD rather then Adam.
-      # After the best policy is figured out, final quantizing is still with Adam.
-      # TODO:find a better way solving the problem
-      if FLAGS.nuql_opt_mode != 'weights':
+      if FLAGS.nuql_opt_mode in ['cluster', 'both']:
         if FLAGS.nuql_opt_mode == 'both':
           optimizable_vars = self.trainable_vars
         else:
           optimizable_vars = clusters
-        if  FLAGS.nuql_enbl_rl_agent == True:  
+        if  FLAGS.nuql_enbl_rl_agent:  
           optimizer_fintune = tf.train.GradientDescentOptimizer(lrn_rate)
           if FLAGS.enbl_multi_gpu:
-            optimizer_fintune = mgw.DistributedOptimizer(optimizer_fintune) # optimizer_fintune is for fintuning during rl-rollouts.
+            optimizer_fintune = mgw.DistributedOptimizer(optimizer_fintune) 
           grads_fintune = optimizer_fintune.compute_gradients(loss, var_list=optimizable_vars)
 
       elif FLAGS.nuql_opt_mode == 'weights':

--- a/learners/nonuniform_quantization/learner.py
+++ b/learners/nonuniform_quantization/learner.py
@@ -260,7 +260,7 @@ class NonUniformQuantLearner(AbstractLearner):
           optimizable_vars = self.trainable_vars
         else:
           optimizable_vars = clusters
-        if  FLAGS.nuql_enbl_rl_agent:  
+        if FLAGS.nuql_enbl_rl_agent:  
           optimizer_fintune = tf.train.GradientDescentOptimizer(lrn_rate)
           if FLAGS.enbl_multi_gpu:
             optimizer_fintune = mgw.DistributedOptimizer(optimizer_fintune) 


### PR DESCRIPTION
A naive way to by pass the shape error in issue #76. During rl rollouts, fintuning is done with a GradientDescentOptimizer rather than AdamOptimizer. After the rl-agent find out optimal compressing policy. The final quantizing is carried out with AdamOptimizer.

Experiment conducted on cifar10 with ResNet56. Fintuning with GradientDescentOptimizer will not do harm to rl agent training.