### PR TITLE
Setup learning rate in each ModelHelper

### DIFF
--- a/learners/abstract_learner.py
+++ b/learners/abstract_learner.py
@@ -77,6 +77,7 @@ class AbstractLearner(ABC):  # pylint: disable=too-many-instance-attributes
     self.forward_train = model_helper.forward_train
     self.forward_eval = model_helper.forward_eval
     self.calc_loss = model_helper.calc_loss
+    self.setup_lrn_rate = model_helper.setup_lrn_rate
     self.model_name = model_helper.model_name
     self.dataset_name = model_helper.dataset_name
 

--- a/learners/channel_pruning/learner.py
+++ b/learners/channel_pruning/learner.py
@@ -27,7 +27,6 @@ import tensorflow as tf
 from tensorflow.contrib import graph_editor
 
 from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
-from utils.lrn_rate_utils import setup_lrn_rate
 from learners.distillation_helper import DistillationHelper
 from learners.abstract_learner import AbstractLearner
 from learners.channel_pruning.model_wrapper import Model
@@ -352,8 +351,7 @@ class ChannelPrunedLearner(AbstractLearner):  # pylint: disable=too-many-instanc
 
       global_step = tf.get_variable('global_step', shape=[], dtype=tf.int32, trainable=False)
       self.global_step = global_step
-      lrn_rate, self.nb_iters_train = setup_lrn_rate(
-        self.global_step, self.model_name, self.dataset_name)
+      lrn_rate, self.nb_iters_train = self.setup_lrn_rate(self.global_step)
 
       if finetune and not FLAGS.cp_retrain:
         mom_optimizer = tf.train.AdamOptimizer(FLAGS.cp_lrn_rate_ft)

--- a/learners/channel_pruning_gpu/learner.py
+++ b/learners/channel_pruning_gpu/learner.py
@@ -25,7 +25,6 @@ import tensorflow as tf
 
 from learners.abstract_learner import AbstractLearner
 from learners.distillation_helper import DistillationHelper
-from utils.lrn_rate_utils import setup_lrn_rate
 from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
 
 FLAGS = tf.app.flags.FLAGS
@@ -235,8 +234,7 @@ class ChannelPrunedGpuLearner(AbstractLearner):  # pylint: disable=too-many-inst
 
         # learning rate schedule
         self.global_step = tf.train.get_or_create_global_step()
-        lrn_rate, self.nb_iters_train = setup_lrn_rate(
-          self.global_step, self.model_name, self.dataset_name)
+        lrn_rate, self.nb_iters_train = self.setup_lrn_rate(self.global_step)
 
         # overall pruning ratios of trainable & maskable variables
         pr_trainable = calc_prune_ratio(self.vars_prnd['trainable'])

--- a/learners/discr_channel_pruning/learner.py
+++ b/learners/discr_channel_pruning/learner.py
@@ -25,7 +25,6 @@ import tensorflow as tf
 
 from learners.abstract_learner import AbstractLearner
 from learners.distillation_helper import DistillationHelper
-from utils.lrn_rate_utils import setup_lrn_rate
 from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
 
 FLAGS = tf.app.flags.FLAGS
@@ -225,8 +224,7 @@ class DisChnPrunedLearner(AbstractLearner):  # pylint: disable=too-many-instance
 
         # learning rate schedule
         self.global_step = tf.train.get_or_create_global_step()
-        lrn_rate, self.nb_iters_train = setup_lrn_rate(
-          self.global_step, self.model_name, self.dataset_name)
+        lrn_rate, self.nb_iters_train = self.setup_lrn_rate(self.global_step)
 
         # overall pruning ratios of trainable & maskable variables
         pr_trainable = calc_prune_ratio(self.vars_prnd['trainable'])

--- a/learners/full_precision/learner.py
+++ b/learners/full_precision/learner.py
@@ -23,7 +23,6 @@ import tensorflow as tf
 
 from learners.abstract_learner import AbstractLearner
 from learners.distillation_helper import DistillationHelper
-from utils.lrn_rate_utils import setup_lrn_rate
 from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
 
 FLAGS = tf.app.flags.FLAGS
@@ -139,8 +138,7 @@ class FullPrecLearner(AbstractLearner):  # pylint: disable=too-many-instance-att
         # optimizer & gradients
         if is_train:
           self.global_step = tf.train.get_or_create_global_step()
-          lrn_rate, self.nb_iters_train = setup_lrn_rate(
-            self.global_step, self.model_name, self.dataset_name)
+          lrn_rate, self.nb_iters_train = self.setup_lrn_rate(self.global_step)
           optimizer = tf.train.MomentumOptimizer(lrn_rate, FLAGS.momentum)
           if FLAGS.enbl_multi_gpu:
             optimizer = mgw.DistributedOptimizer(optimizer)

--- a/learners/uniform_quantization_tf/learner.py
+++ b/learners/uniform_quantization_tf/learner.py
@@ -23,7 +23,6 @@ import tensorflow as tf
 
 from learners.abstract_learner import AbstractLearner
 from learners.distillation_helper import DistillationHelper
-from utils.lrn_rate_utils import setup_lrn_rate
 from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
 
 FLAGS = tf.app.flags.FLAGS
@@ -189,8 +188,7 @@ class UniformQuantTFLearner(AbstractLearner):  # pylint: disable=too-many-instan
 
         # learning rate schedule
         self.global_step = tf.train.get_or_create_global_step()
-        lrn_rate, self.nb_iters_train = setup_lrn_rate(
-          self.global_step, self.model_name, self.dataset_name)
+        lrn_rate, self.nb_iters_train = self.setup_lrn_rate(self.global_step)
         lrn_rate *= FLAGS.uqtf_lrn_rate_dcy
 
         # decrease the learning rate by a constant factor

--- a/learners/weight_sparsification/learner.py
+++ b/learners/weight_sparsification/learner.py
@@ -25,7 +25,6 @@ from learners.abstract_learner import AbstractLearner
 from learners.distillation_helper import DistillationHelper
 from learners.weight_sparsification.pr_optimizer import PROptimizer
 from learners.weight_sparsification.utils import get_maskable_vars
-from utils.lrn_rate_utils import setup_lrn_rate
 from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
 
 FLAGS = tf.app.flags.FLAGS
@@ -185,8 +184,7 @@ class WeightSparseLearner(AbstractLearner):  # pylint: disable=too-many-instance
 
         # learning rate schedule
         self.global_step = tf.train.get_or_create_global_step()
-        lrn_rate, self.nb_iters_train = setup_lrn_rate(
-          self.global_step, self.model_name, self.dataset_name)
+        lrn_rate, self.nb_iters_train = self.setup_lrn_rate(self.global_step)
 
         # overall pruning ratios of trainable & maskable variables
         pr_trainable = calc_prune_ratio(self.trainable_vars)

--- a/nets/abstract_model_helper.py
+++ b/nets/abstract_model_helper.py
@@ -102,6 +102,19 @@ class AbstractModelHelper(ABC):
     """
     pass
 
+  @abstractmethod
+  def setup_lrn_rate(self, global_step):
+    """Setup the learning rate (and number of training iterations).
+
+    Args:
+    * global_step: training iteration counter
+
+    Returns:
+    * lrn_rate: learning rate
+    * nb_iters: number of training iterations
+    """
+    pass
+
   @property
   @abstractmethod
   def model_name(self):

--- a/nets/lenet_at_cifar10.py
+++ b/nets/lenet_at_cifar10.py
@@ -25,6 +25,7 @@ from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
 
 FLAGS = tf.app.flags.FLAGS
 
+tf.app.flags.DEFINE_float('nb_epochs_rat', 1.0, '# of training epochs\'s ratio')
 tf.app.flags.DEFINE_float('lrn_rate_init', 1e-2, 'initial learning rate')
 tf.app.flags.DEFINE_float('batch_size_norm', 128, 'normalization factor of batch size')
 tf.app.flags.DEFINE_float('momentum', 0.9, 'momentum coefficient')

--- a/nets/mobilenet_at_ilsvrc12.py
+++ b/nets/mobilenet_at_ilsvrc12.py
@@ -31,6 +31,7 @@ FLAGS = tf.app.flags.FLAGS
 
 tf.app.flags.DEFINE_integer('mobilenet_version', 1, 'MobileNet\'s version (1 or 2)')
 tf.app.flags.DEFINE_float('mobilenet_depth_mult', 1.0, 'MobileNet\'s depth multiplier')
+tf.app.flags.DEFINE_float('nb_epochs_rat', 1.0, '# of training epochs\'s ratio')
 tf.app.flags.DEFINE_float('lrn_rate_init', 0.045, 'initial learning rate')
 tf.app.flags.DEFINE_float('batch_size_norm', 96, 'normalization factor of batch size')
 tf.app.flags.DEFINE_float('momentum', 0.9, 'momentum coefficient')

--- a/nets/resnet_at_cifar10.py
+++ b/nets/resnet_at_cifar10.py
@@ -27,6 +27,7 @@ from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
 FLAGS = tf.app.flags.FLAGS
 
 tf.app.flags.DEFINE_integer('resnet_size', 20, '# of layers in the ResNet model')
+tf.app.flags.DEFINE_float('nb_epochs_rat', 1.0, '# of training epochs\'s ratio')
 tf.app.flags.DEFINE_float('lrn_rate_init', 1e-1, 'initial learning rate')
 tf.app.flags.DEFINE_float('batch_size_norm', 128, 'normalization factor of batch size')
 tf.app.flags.DEFINE_float('momentum', 0.9, 'momentum coefficient')

--- a/nets/resnet_at_cifar10.py
+++ b/nets/resnet_at_cifar10.py
@@ -21,6 +21,8 @@ import tensorflow as tf
 from nets.abstract_model_helper import AbstractModelHelper
 from datasets.cifar10_dataset import Cifar10Dataset
 from utils.external import resnet_model as ResNet
+from utils.lrn_rate_utils import setup_lrn_rate_piecewise_constant
+from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
 
 FLAGS = tf.app.flags.FLAGS
 
@@ -107,6 +109,18 @@ class ModelHelper(AbstractModelHelper):
     metrics = {'accuracy': accuracy}
 
     return loss, metrics
+
+  def setup_lrn_rate(self, global_step):
+    """Setup the learning rate (and number of training iterations)."""
+
+    nb_epochs = 250
+    idxs_epoch = [100, 150, 200]
+    decay_rates = [1.0, 0.1, 0.01, 0.001]
+    batch_size = FLAGS.batch_size * (1 if not FLAGS.enbl_multi_gpu else mgw.size())
+    lrn_rate = setup_lrn_rate_piecewise_constant(global_step, batch_size, idxs_epoch, decay_rates)
+    nb_iters = int(FLAGS.nb_smpls_train * nb_epochs * FLAGS.nb_epochs_rat / batch_size)
+
+    return lrn_rate, nb_iters
 
   @property
   def model_name(self):

--- a/nets/resnet_at_ilsvrc12.py
+++ b/nets/resnet_at_ilsvrc12.py
@@ -21,6 +21,8 @@ import tensorflow as tf
 from nets.abstract_model_helper import AbstractModelHelper
 from datasets.ilsvrc12_dataset import Ilsvrc12Dataset
 from utils.external import resnet_model as ResNet
+from utils.lrn_rate_utils import setup_lrn_rate_piecewise_constant
+from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
 
 FLAGS = tf.app.flags.FLAGS
 
@@ -136,6 +138,18 @@ class ModelHelper(AbstractModelHelper):
     metrics = {'accuracy': acc_top5, 'acc_top1': acc_top1, 'acc_top5': acc_top5}
 
     return loss, metrics
+
+  def setup_lrn_rate(self, global_step):
+    """Setup the learning rate (and number of training iterations)."""
+
+    nb_epochs = 100
+    idxs_epoch = [30, 60, 80, 90]
+    decay_rates = [1.0, 0.1, 0.01, 0.001, 0.0001]
+    batch_size = FLAGS.batch_size * (1 if not FLAGS.enbl_multi_gpu else mgw.size())
+    lrn_rate = setup_lrn_rate_piecewise_constant(global_step, batch_size, idxs_epoch, decay_rates)
+    nb_iters = int(FLAGS.nb_smpls_train * nb_epochs * FLAGS.nb_epochs_rat / batch_size)
+
+    return lrn_rate, nb_iters
 
   @property
   def model_name(self):

--- a/nets/resnet_at_ilsvrc12.py
+++ b/nets/resnet_at_ilsvrc12.py
@@ -27,6 +27,7 @@ from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
 FLAGS = tf.app.flags.FLAGS
 
 tf.app.flags.DEFINE_integer('resnet_size', 18, '# of layers in the ResNet model')
+tf.app.flags.DEFINE_float('nb_epochs_rat', 1.0, '# of training epochs\'s ratio')
 tf.app.flags.DEFINE_float('lrn_rate_init', 1e-1, 'initial learning rate')
 tf.app.flags.DEFINE_float('batch_size_norm', 256, 'normalization factor of batch size')
 tf.app.flags.DEFINE_float('momentum', 0.9, 'momentum coefficient')

--- a/utils/lrn_rate_utils.py
+++ b/utils/lrn_rate_utils.py
@@ -18,25 +18,7 @@
 
 import tensorflow as tf
 
-from utils.multi_gpu_wrapper import MultiGpuWrapper as mgw
-
 FLAGS = tf.app.flags.FLAGS
-
-# set <nb_epochs_rat> to values smaller than 1.0 to use fewer epochs and speed up training
-tf.app.flags.DEFINE_float('nb_epochs_rat', 1.0, '# of training epochs\'s ratio')
-
-def calc_nb_batches(nb_epochs, batch_size):
-  """Calculate the number of mini-batches.
-
-  Args:
-  * nb_epochs: number of epoches
-  * batch_size: number of samples in each mini-batch
-
-  Returns:
-  * nb_batches: number of mini-batches
-  """
-
-  return int(FLAGS.nb_smpls_train * nb_epochs * FLAGS.nb_epochs_rat / batch_size)
 
 def setup_lrn_rate_piecewise_constant(global_step, batch_size, idxs_epoch, decay_rates):
   """Setup the learning rate with piecewise constant strategy.
@@ -51,7 +33,7 @@ def setup_lrn_rate_piecewise_constant(global_step, batch_size, idxs_epoch, decay
   * lrn_rate: learning rate
   """
 
-  # adjust the interval endpoints
+  # adjust interval endpoints w.r.t. FLAGS.nb_epochs_rat
   idxs_epoch = [idx_epoch * FLAGS.nb_epochs_rat for idx_epoch in idxs_epoch]
 
   # setup learning rate with the piecewise constant strategy
@@ -59,8 +41,9 @@ def setup_lrn_rate_piecewise_constant(global_step, batch_size, idxs_epoch, decay
   nb_batches_per_epoch = float(FLAGS.nb_smpls_train) / batch_size
   bnds = [int(nb_batches_per_epoch * idx_epoch) for idx_epoch in idxs_epoch]
   vals = [lrn_rate_init * decay_rate for decay_rate in decay_rates]
+  lrn_rate = tf.train.piecewise_constant(global_step, bnds, vals)
 
-  return tf.train.piecewise_constant(global_step, bnds, vals)
+  return lrn_rate
 
 def setup_lrn_rate_exponential_decay(global_step, batch_size, epoch_step, decay_rate):
   """Setup the learning rate with exponential decaying strategy.
@@ -75,154 +58,13 @@ def setup_lrn_rate_exponential_decay(global_step, batch_size, epoch_step, decay_
   * lrn_rate: learning rate
   """
 
-  # adjust the step size & decaying rate
+  # adjust the step size & decaying rate w.r.t. FLAGS.nb_epochs_rat
   epoch_step *= FLAGS.nb_epochs_rat
 
   # setup learning rate with the exponential decay strategy
   lrn_rate_init = FLAGS.lrn_rate_init * batch_size / FLAGS.batch_size_norm
   batch_step = int(FLAGS.nb_smpls_train * epoch_step / batch_size)
+  lrn_rate = tf.train.exponential_decay(
+    lrn_rate_init, tf.cast(global_step, tf.int32), batch_step, decay_rate, staircase=True)
 
-  return tf.train.exponential_decay(
-    lrn_rate_init, global_step, batch_step, decay_rate, staircase=True)
-
-def setup_lrn_rate_lenet_cifar10(global_step, batch_size):
-  """Setup the learning rate for LeNet-like models on the CIFAR-10 dataset.
-
-  Args:
-  * global_step: training iteration counter
-  * batch_size: number of samples in each mini-batch
-
-  Returns:
-  * lrn_rate: learning rate
-  * nb_batches: number of mini-batches
-  """
-
-  nb_epochs = 250
-  idxs_epoch = [100, 150, 200]
-  decay_rates = [1.0, 0.1, 0.01, 0.001]
-  lrn_rate = setup_lrn_rate_piecewise_constant(global_step, batch_size, idxs_epoch, decay_rates)
-  nb_batches = calc_nb_batches(nb_epochs, batch_size)
-
-  return lrn_rate, nb_batches
-
-def setup_lrn_rate_resnet_cifar10(global_step, batch_size):
-  """Setup the learning rate for ResNet models on the CIFAR-10 dataset.
-
-  Args:
-  * global_step: training iteration counter
-  * batch_size: number of samples in each mini-batch
-
-  Returns:
-  * lrn_rate: learning rate
-  * nb_batches: number of mini-batches
-  """
-
-  nb_epochs = 250
-  idxs_epoch = [100, 150, 200]
-  decay_rates = [1.0, 0.1, 0.01, 0.001]
-  lrn_rate = setup_lrn_rate_piecewise_constant(global_step, batch_size, idxs_epoch, decay_rates)
-  nb_batches = calc_nb_batches(nb_epochs, batch_size)
-
-  return lrn_rate, nb_batches
-
-def setup_lrn_rate_resnet_ilsvrc12(global_step, batch_size):
-  """Setup the learning rate for ResNet models on the ILSVRC-12 dataset.
-
-  Args:
-  * global_step: training iteration counter
-  * batch_size: number of samples in each mini-batch
-
-  Returns:
-  * lrn_rate: learning rate
-  * nb_batches: number of mini-batches
-  """
-
-  nb_epochs = 100
-  idxs_epoch = [30, 60, 80, 90]
-  decay_rates = [1.0, 0.1, 0.01, 0.001, 0.0001]
-  lrn_rate = setup_lrn_rate_piecewise_constant(global_step, batch_size, idxs_epoch, decay_rates)
-  nb_batches = calc_nb_batches(nb_epochs, batch_size)
-
-  return lrn_rate, nb_batches
-
-def setup_lrn_rate_mobilenet_v1_ilsvrc12(global_step, batch_size):
-  """Setup the learning rate for MobileNet-v1 models on the ILSVRC-12 dataset.
-
-  Args:
-  * global_step: training iteration counter
-  * batch_size: number of samples in each mini-batch
-
-  Returns:
-  * lrn_rate: learning rate
-  * nb_batches: number of mini-batches
-  """
-
-  nb_epochs = 100
-  idxs_epoch = [30, 60, 80, 90]
-  decay_rates = [1.0, 0.1, 0.01, 0.001, 0.0001]
-  lrn_rate = setup_lrn_rate_piecewise_constant(global_step, batch_size, idxs_epoch, decay_rates)
-  nb_batches = calc_nb_batches(nb_epochs, batch_size)
-
-  return lrn_rate, nb_batches
-
-def setup_lrn_rate_mobilenet_v2_ilsvrc12(global_step, batch_size):
-  """Setup the learning rate for MobileNet-v2 models on the ILSVRC-12 dataset.
-
-  Args:
-  * global_step: training iteration counter
-  * batch_size: number of samples in each mini-batch
-
-  Returns:
-  * lrn_rate: learning rate
-  * nb_batches: number of mini-batches
-  """
-
-  nb_epochs = 412
-  epoch_step = 2.5
-  decay_rate = 0.98 ** epoch_step
-  lrn_rate = setup_lrn_rate_exponential_decay(global_step, batch_size, epoch_step, decay_rate)
-  nb_batches = calc_nb_batches(nb_epochs, batch_size)
-
-  return lrn_rate, nb_batches
-
-def setup_lrn_rate(global_step, model_name, dataset_name):
-  """Setup the learning rate for the given dataset.
-
-  Args:
-  * global_step: training iteration counter
-  * model_name: model's name; must be one of ['lenet', 'resnet_*', 'mobilenet_v1', 'mobilenet_v2']
-  * dataset_name: dataset's name; must be one of ['cifar_10', 'ilsvrc_12']
-
-  Returns:
-  * lrn_rate: learning rate
-  * nb_batches: number of training mini-batches
-  """
-
-  # obtain the overall batch size across all GPUs
-  if not FLAGS.enbl_multi_gpu:
-    batch_size = FLAGS.batch_size
-  else:
-    batch_size = FLAGS.batch_size * mgw.size()
-
-  # choose a learning rate protocol according to the model & dataset combination
-  global_step = tf.cast(global_step, tf.int32)
-  if dataset_name == 'cifar_10':
-    if model_name == 'lenet':
-      lrn_rate, nb_batches = setup_lrn_rate_lenet_cifar10(global_step, batch_size)
-    elif model_name.startswith('resnet'):
-      lrn_rate, nb_batches = setup_lrn_rate_resnet_cifar10(global_step, batch_size)
-    else:
-      raise NotImplementedError('model: {} / dataset: {}'.format(model_name, dataset_name))
-  elif dataset_name == 'ilsvrc_12':
-    if model_name.startswith('resnet'):
-      lrn_rate, nb_batches = setup_lrn_rate_resnet_ilsvrc12(global_step, batch_size)
-    elif model_name.startswith('mobilenet_v1'):
-      lrn_rate, nb_batches = setup_lrn_rate_mobilenet_v1_ilsvrc12(global_step, batch_size)
-    elif model_name.startswith('mobilenet_v2'):
-      lrn_rate, nb_batches = setup_lrn_rate_mobilenet_v2_ilsvrc12(global_step, batch_size)
-    else:
-      raise NotImplementedError('model: {} / dataset: {}'.format(model_name, dataset_name))
-  else:
-    raise NotImplementedError('dataset: ' + dataset_name)
-
-  return lrn_rate, nb_batches
+  return lrn_rate


### PR DESCRIPTION
Move the `setup_lrn_rate` function's implementation into each `ModelHelper` class.

Previously, the `setup_lrn_rate` function is implemented in `utils/lrn_rate_utils.py`. This means that whenever a new model or data set is added, users have to modify the implementation in `utils/lrn_rate_utils.py`, which is less convenient and sometimes dangerous. In this pull request, we require each `ModelHelper` class to provide its own learning rate schedule (we add an abstract method "setup_lrn_rate" in the `AbstractModelHelper` class).