### PR TITLE
Bugfix: unable to collect all extra arguments in the execution script

### DIFF
--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -14,6 +14,7 @@ nb_gpus=1
 # parse arguments passed from the command line
 py_script="$1"
 shift
+extra_args=""
 for i in "$@"
 do
   case "$i" in
@@ -23,11 +24,13 @@ do
     ;;
     *)
     # unknown option
+    extra_args="${extra_args} ${i}"
+    shift
     ;;
   esac
 done
-extra_args=`python utils/get_path_args.py docker ${py_script} path.conf`
-extra_args="$@ ${extra_args}"
+extra_args_path=`python utils/get_path_args.py docker ${py_script} path.conf`
+extra_args="${extra_args} ${extra_args_path}"
 echo ${extra_args} > extra_args
 echo "Python script: ${py_script}"
 echo "Data directory: ${dir_data}"

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -6,6 +6,7 @@ nb_gpus=1
 # parse arguments passed from the command line
 py_script="$1"
 shift
+extra_args=""
 for i in "$@"
 do
   case "$i" in
@@ -15,11 +16,13 @@ do
     ;;
     *)
     # unknown option
+    extra_args="${extra_args} ${i}"
+    shift
     ;;
   esac
 done
-extra_args=`python utils/get_path_args.py local ${py_script} path.conf`
-extra_args="$@ ${extra_args}"
+extra_args_path=`python utils/get_path_args.py local ${py_script} path.conf`
+extra_args="${extra_args} ${extra_args_path}"
 echo "Python script: ${py_script}"
 echo "# of GPUs: ${nb_gpus}"
 echo "extra arguments: ${extra_args}"

--- a/scripts/run_seven.sh
+++ b/scripts/run_seven.sh
@@ -15,6 +15,7 @@ job_name="pocket-flow"
 # parse arguments passed from the command line
 py_script="$1"
 shift
+extra_args=""
 for i in "$@"
 do
   case "$i" in
@@ -28,11 +29,13 @@ do
     ;;
     *)
     # unknown option
+    extra_args="${extra_args} ${i}"
+    shift
     ;;
   esac
 done
-extra_args=`python utils/get_path_args.py seven ${py_script} path.conf`
-extra_args="$@ ${extra_args}"
+extra_args_path=`python utils/get_path_args.py seven ${py_script} path.conf`
+extra_args="${extra_args} ${extra_args_path}"
 echo ${extra_args} > extra_args
 echo "Python script: ${py_script}"
 echo "Job name: ${job_name}"


### PR DESCRIPTION
This PR resolves the bug discovered in issue #154.

Previously, the execution script will search for the "-n=x" and "-j=y" options and shift once whenever any of these two options is found. If "-n=x" and "-j=y" options are placed after some other extra arguments, these arguments may be wrongly ignored. This is fixed in this PR.