### PR TITLE
Channel Pruning for SSD

### DIFF
--- a/learners/channel_pruning_rmt/learner.py
+++ b/learners/channel_pruning_rmt/learner.py
@@ -647,9 +647,7 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
     outputs_smpl_prnd = np.vstack(outputs_smpl_prnd_list)
 
     # concatenate sampled inputs & outputs arrays
-    inputs_smpl = np.split(inputs_smpl_prnd, ic, axis=3)  # one per input channel
-    for idx in range(ic):
-      inputs_smpl[idx] = np.reshape(inputs_smpl[idx], [-1, kh * kw])
+    inputs_smpl = [np.reshape(x, [-1, kh * kw]) for x in np.split(inputs_smpl_prnd, ic, axis=3)]
     outputs_smpl = outputs_smpl_full
 
     # validate inputs & outputs

--- a/learners/channel_pruning_rmt/learner.py
+++ b/learners/channel_pruning_rmt/learner.py
@@ -806,7 +806,7 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
     tf.logging.info('determining <gamma> via binary search')
     time_beg = timer()
     lbnd = 0.0
-    while nb_chns_nnz != nb_chns_nnz_target:
+    while nb_chns_nnz != nb_chns_nnz_target and ubnd - lbnd > 1e-8:
       val = (lbnd + ubnd) / 2.0
       mask_np, nb_chns_nnz = __solve_lasso(val)
       if nb_chns_nnz < nb_chns_nnz_target:

--- a/learners/channel_pruning_rmt/learner.py
+++ b/learners/channel_pruning_rmt/learner.py
@@ -161,13 +161,12 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
       tf.logging.info('model restored from ' + save_path)
     else:
       self.__choose_channels()
-    tf.logging.info('time (channel selection): %.2f (s)' % (timer() - time_prev))
+      tf.logging.info('time (channel selection): %.2f (s)' % (timer() - time_prev))
     self.sess_train.run(self.mask_updt_op)
     if FLAGS.enbl_multi_gpu:
       self.sess_train.run(self.bcast_op)
 
     # evaluate the model before fine-tuning
-    tf.logging.info('evaluating the model before fine-tuning')
     if self.is_primary_worker('global'):
       self.__save_model(is_train=True)
       self.evaluate()

--- a/learners/channel_pruning_rmt/learner.py
+++ b/learners/channel_pruning_rmt/learner.py
@@ -43,6 +43,10 @@ tf.app.flags.DEFINE_integer('cpr_ista_nb_iters', 100, 'CPR: # of iterations in I
 tf.app.flags.DEFINE_float('cpr_lstsq_lrn_rate', 1e-3, 'CPR: least-sqaure regression\'s learning rate')
 tf.app.flags.DEFINE_integer('cpr_lstsq_nb_iters', 100, 'CPR: # of iterations in least-square regression')
 tf.app.flags.DEFINE_boolean('cpr_eval_per_layer', False, 'CPR: evaluate whenever a layer is pruned')
+tf.app.flags.DEFINE_boolean('cpr_warm_start', False,
+                            'CPR: use a channel-pruned model for warm start '
+                            '(the channel selection process will be skipped)')
+tf.app.flags.DEFINE_string('cpr_save_path_ws', None, 'CPR: model\'s save path for warm start')
 
 def get_vars_by_scope(scope):
   """Get list of variables within certain name scope.

--- a/utils/get_idle_gpus.py
+++ b/utils/get_idle_gpus.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Get a list of idle GPUs."""
+"""Get a list of idle GPUs.
+
+This script sorts GPUs in the ascending order of memory usage, and return the top-k ones.
+"""
 
 import os
 import sys
@@ -25,7 +28,7 @@ assert len(sys.argv) == 2
 nb_idle_gpus = int(sys.argv[1])
 
 # assume: idle gpu has no more than 50% of total card memory used
-max_gpu_usage_threshold = .5
+mem_usage_ulimit = .5
 
 # command to execute to get gpu id and corresponding memory used
 # and total memory. It gives output in the format
@@ -36,17 +39,16 @@ gpu_smi_output = subprocess.check_output(cmd, shell=True)
 gpu_smi_output = gpu_smi_output.decode('utf-8')
 
 idle_gpus = []
-
 for gpu in gpu_smi_output.split(sep='\n')[:-1]:
-  (gpu_id, used, total) = [int(value) for value in gpu.split(sep=',')]
-  memory_usage_percentage = (used/total)
-  if memory_usage_percentage < max_gpu_usage_threshold:
-    # GPU usage is less than the threshold
-    idle_gpus.append(gpu_id)
+  (gpu_id, mem_used, mem_total) = [int(value) for value in gpu.split(sep=',')]
+  mem_usage = float(mem_used) / mem_total
+  if mem_usage < mem_usage_ulimit:
+    idle_gpus += [(gpu_id, mem_usage)]
+idle_gpus.sort(key=lambda x: x[1])
+idle_gpus = [x[0] for x in idle_gpus]  # only keep GPU ids
 
 if len(idle_gpus) < nb_idle_gpus:
-  raise ValueError('not enough idle GPUs;'
-                   ' idle GPUs are: {}'.format(idle_gpus))
+  raise ValueError('not enough idle GPUs; idle GPUs are: {}'.format(idle_gpus))
 idle_gpus = idle_gpus[:nb_idle_gpus]
 idle_gpus_str = ','.join([str(idle_gpu) for idle_gpu in idle_gpus])
 print(idle_gpus_str)


### PR DESCRIPTION
In this PR, we have updated the implementation of `ChannelPrunedRmtLearner` so that it is now capable of compression SSD models. Below is the detailed results:

Model: SSD-VGG-16
Uncompressed model's mAP: 77.64%

| Pruned Layers | Prune Ratio | FLOPs | mAP |
|:-:|:-:|:-:|:-:|
| Backbone-only | 0.2 | 67.34% | 77.43% |
| Backbone-only | 0.3 | 53.58% | 77.05% |
| Backbone-only | 0.4 | 41.63% | 75.47% |
| Backbone-only | 0.5 | 31.56% | 73.29% |
| All layers | 0.2 | 66.50% | 76.98% |
| All layers | 0.3 | 52.32% | 76.42% |
| All layers | 0.4 | 39.96% | 74.89% |
| All layers | 0.5 | 29.47% | 72.48% |

**Usage:**
```bash
# backbone-only
$ ./scripts/run_docker.sh nets/vgg_at_pascalvoc_run.py -n=4 \
    --learner=chn-pruned-rmt \
    --cpr_prune_ratio=0.2 \
    --batch_size=8

# all layers
$ ./scripts/run_docker.sh nets/vgg_at_pascalvoc_run.py -n=4 \
    --learner=chn-pruned-rmt \
    --cpr_prune_ratio=0.2 \
    --batch_size=8 \
    --cpr_skip_op_names=multibox_head
```

P.S.: A minor update to `utils/get_idle_gpus.py`. It now returns top-k GPUs with least memory occupation.