### PR TITLE
Optimized Performance of ChannelPrunedRmtLearner

### DIFF
--- a/learners/channel_pruning_rmt/learner.py
+++ b/learners/channel_pruning_rmt/learner.py
@@ -487,11 +487,6 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
       'mask': mask,
       'init_op': init_op,
       'train_op': train_op,
-      'null_fd': {
-        xt_x_ph: np.zeros((1, 1)),
-        xt_y_ph: np.zeros((1, 1)),
-        mask_ph: np.zeros((1, 1)),
-      },
     }
 
     return meta_lasso
@@ -499,64 +494,35 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
   def __build_meta_lstsq(self):
     """Build a meta least-square optimization problem."""
 
-    beta1 = 0.9
-    beta2 = 0.999
-    epsilon = 1e-8
-
     # build a meta least-square optimization problem
     with tf.variable_scope('meta_lstsq'):
       # create placeholders to customize the least-square problem
       x_mat_ph = tf.placeholder(tf.float32, name='x_mat_ph')
       y_mat_ph = tf.placeholder(tf.float32, name='y_mat_ph')
       w_mat_ph = tf.placeholder(tf.float32, name='w_mat_ph')
-      gacc1_ph = tf.placeholder(tf.float32, name='gacc1_ph')
-      gacc2_ph = tf.placeholder(tf.float32, name='gacc2_ph')
 
       # create variables
       x_mat = tf.get_variable('x_mat', initializer=x_mat_ph, validate_shape=False)
       y_mat = tf.get_variable('y_mat', initializer=y_mat_ph, validate_shape=False)
       w_mat = tf.get_variable('w_mat', initializer=w_mat_ph, validate_shape=False)
-      gacc1 = tf.get_variable('gacc1', initializer=gacc1_ph, validate_shape=False)
-      gacc2 = tf.get_variable('gacc2', initializer=gacc2_ph, validate_shape=False)
-      train_step = tf.get_variable('train_step', shape=[], initializer=tf.zeros_initializer)
 
       # TF operations
       nb_smpls = tf.cast(tf.shape(x_mat)[0], tf.float32)
       loss_reg = tf.nn.l2_loss(tf.matmul(x_mat, w_mat) - y_mat) / nb_smpls
       loss_dcy = FLAGS.loss_w_dcy * tf.nn.l2_loss(w_mat)
-      grad = tf.matmul(tf.transpose(x_mat), tf.matmul(x_mat, w_mat) - y_mat) / nb_smpls + FLAGS.loss_w_dcy * w_mat
-      update_ops = [
-        gacc1.assign(beta1 * gacc1 + (1.0 - beta1) * grad),
-        gacc2.assign(beta2 * gacc2 + (1.0 - beta2) * grad ** 2),
-        train_step.assign_add(tf.ones([]))
-      ]
-      with tf.control_dependencies(update_ops):
-        lrn_rate = FLAGS.cpr_lstsq_lrn_rate \
-          * tf.sqrt(1.0 - tf.pow(beta2, train_step)) / (1.0 - tf.pow(beta1, train_step))
-        train_op = w_mat.assign_add(-lrn_rate * gacc1 / (tf.sqrt(gacc2) + epsilon))
-      init_op = tf.variables_initializer([x_mat, y_mat, w_mat, gacc1, gacc2, train_step])
-
       train_op = w_mat.assign(tf.linalg.lstsq(x_mat, y_mat, l2_regularizer=FLAGS.loss_w_dcy))
+      init_op = tf.variables_initializer([x_mat, y_mat, w_mat])
 
     # pack placeholders and variables into dict
     meta_lstsq = {
       'x_mat_ph': x_mat_ph,
       'y_mat_ph': y_mat_ph,
       'w_mat_ph': w_mat_ph,
-      'gacc1_ph': gacc1_ph,
-      'gacc2_ph': gacc2_ph,
       'w_mat': w_mat,
       'loss_reg': loss_reg,
       'loss_dcy': loss_dcy,
       'init_op': init_op,
       'train_op': train_op,
-      'null_fd': {
-        x_mat_ph: np.zeros((1, 1)),
-        y_mat_ph: np.zeros((1, 1)),
-        w_mat_ph: np.zeros((1, 1)),
-        gacc1_ph: np.zeros((1, 1)),
-        gacc2_ph: np.zeros((1, 1)),
-      },
     }
 
     return meta_lstsq
@@ -849,20 +815,15 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
     feat_mat_np = np.reshape(
       np.concatenate([np.expand_dims(x, axis=-1) for x in inputs_np_list_msk], axis=-1), [bs, -1])
     w_mat_np_init = np.reshape(conv_krnl * np.reshape(bnry_vec_np, [1, 1, -1, 1]), [-1, oc])
-    gacc1_np = np.zeros_like(w_mat_np_init)
-    gacc2_np = np.zeros_like(w_mat_np_init)
     self.sess_prune.run(self.meta_lstsq['init_op'], feed_dict={
       self.meta_lstsq['x_mat_ph']: feat_mat_np,
       self.meta_lstsq['y_mat_ph']: rspn_mat_np,
       self.meta_lstsq['w_mat_ph']: w_mat_np_init,
-      self.meta_lstsq['gacc1_ph']: gacc1_np,
-      self.meta_lstsq['gacc2_ph']: gacc2_np,
     })
-    w_mat_np, loss_reg, loss_dcy = self.sess_prune.run(
-      [self.meta_lstsq['w_mat'], self.meta_lstsq['loss_reg'], self.meta_lstsq['loss_dcy']])
+    loss_reg, loss_dcy = self.sess_prune.run(
+      [self.meta_lstsq['loss_reg'], self.meta_lstsq['loss_dcy']])
     tf.logging.info('losses: %e (reg) / %e (dcy)' % (loss_reg, loss_dcy))
-    for __ in range(FLAGS.cpr_lstsq_nb_iters):
-      self.sess_prune.run(self.meta_lstsq['train_op'])
+    self.sess_prune.run(self.meta_lstsq['train_op'])
     w_mat_np, loss_reg, loss_dcy = self.sess_prune.run(
       [self.meta_lstsq['w_mat'], self.meta_lstsq['loss_reg'], self.meta_lstsq['loss_dcy']])
     tf.logging.info('losses: %e (reg) / %e (dcy)' % (loss_reg, loss_dcy))

--- a/learners/channel_pruning_rmt/learner.py
+++ b/learners/channel_pruning_rmt/learner.py
@@ -594,7 +594,6 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
         for idx_chn_input in range(nb_chns_input):
           inputs_list[idx_chn_input] += [inputs_smpl[idx_chn_input]]
         outputs_list += [outputs_smpl]
-        tf.logging.info('sampled inputs & outputs (%d / %d)' % (nb_insts, FLAGS.cpr_nb_insts_reg))
       idxs_inst = np.random.choice(nb_insts, size=(FLAGS.cpr_nb_insts_reg), replace=False)
       inputs_np_list = [np.vstack(x)[idxs_inst] for x in inputs_list]
       outputs_np = np.vstack(outputs_list)[idxs_inst]
@@ -609,8 +608,8 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
       tf.logging.info('time elapsed (selection): %.4f (s)' % (timer() - time_beg))
 
       # evaluate the channel pruned model
-      tf.logging.info('evaluating the channel pruned model')
       if FLAGS.cpr_eval_per_layer:
+        tf.logging.info('evaluating the channel pruned model')
         if self.is_primary_worker('global'):
           self.__save_model(is_train=True)
           self.evaluate()
@@ -669,8 +668,6 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
       inputs_smpl_prnd_list += [inputs_smpl_prnd]
       outputs_smpl_full_list += [np.reshape(outputs_full[:, idx_oh, idx_ow, :], [bs, -1])]
       outputs_smpl_prnd_list += [np.reshape(outputs_prnd[:, idx_oh, idx_ow, :], [bs, -1])]
-      if idx_iter == 0:
-        tf.logging.info('inputs_smpl_full.shape = {}'.format(inputs_smpl_full.shape))
 
     # concatenate samples into a single np.array
     inputs_smpl_full = np.concatenate(inputs_smpl_full_list, axis=0)
@@ -681,7 +678,6 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
     # concatenate sampled inputs & outputs arrays
     inputs_smpl = [np.reshape(x, [-1, kh * kw]) for x in np.split(inputs_smpl_prnd, ic, axis=3)]
     outputs_smpl = outputs_smpl_full
-    tf.logging.info('inputs: {} / outputs: {}'.format(inputs_smpl[0].shape, outputs_smpl.shape))
 
     # validate inputs & outputs
     wei_mat_full = np.reshape(conv_krnl_full, [-1, oc])

--- a/learners/channel_pruning_rmt/learner.py
+++ b/learners/channel_pruning_rmt/learner.py
@@ -40,18 +40,11 @@ tf.app.flags.DEFINE_boolean('cpr_skip_frst_layer', True, 'CPR: skip the first la
 tf.app.flags.DEFINE_boolean('cpr_skip_last_layer', False, 'CPR: skip the last layer for pruning')
 tf.app.flags.DEFINE_string('cpr_skip_op_names', None,
                            'CPR: comma-separated Conv2D operations names to be skipped')
-tf.app.flags.DEFINE_integer('cpr_nb_smpls', 500,
+tf.app.flags.DEFINE_integer('cpr_nb_smpls', 5000,
                             'CPR: # of cached training samples for channel pruning')
-tf.app.flags.DEFINE_integer('cpr_nb_insts_reg', 5000,
-                            'CPR: # of sampled instances for regression. '
-                            'For LASSO: one random crop -> <c_o> instances. '
-                            'For least-square regression: one random crop -> one instance.')
 tf.app.flags.DEFINE_integer('cpr_nb_crops_per_smpl', 10, 'CPR: # of random crops per sample')
 tf.app.flags.DEFINE_float('cpr_ista_lrn_rate', 1e-2, 'CPR: ISTA\'s learning rate')
 tf.app.flags.DEFINE_integer('cpr_ista_nb_iters', 100, 'CPR: # of iterations in ISTA')
-tf.app.flags.DEFINE_float('cpr_lstsq_lrn_rate', 1e-3, 'CPR: least-sqaure regression\'s learning rate')
-tf.app.flags.DEFINE_integer('cpr_lstsq_nb_iters', 100, 'CPR: # of iterations in least-square regression')
-tf.app.flags.DEFINE_boolean('cpr_eval_per_layer', False, 'CPR: evaluate whenever a layer is pruned')
 tf.app.flags.DEFINE_boolean('cpr_warm_start', False,
                             'CPR: use a channel-pruned model for warm start '
                             '(the channel selection process will be skipped)')
@@ -625,6 +618,7 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
       self.sess_prune.run(update_op, feed_dict={conv_krnl_prnd_ph: conv_krnl_prnd})
       tf.logging.info('time elapsed (selection): %.4f (s)' % (timer() - time_beg))
 
+      # compute the overall pruning ratios
       pr_trn, pr_krn = self.sess_prune.run([self.pr_trn_prune, self.pr_krn_prune])
       tf.logging.info('pruning ratios: %e (trn) / %e (krn)' % (pr_trn, pr_krn))
 

--- a/learners/channel_pruning_rmt/learner.py
+++ b/learners/channel_pruning_rmt/learner.py
@@ -738,7 +738,7 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
     xt_x_norm = norm(xt_x_np)  # normalize <xt_x> to unit norm, and adjust <xt_y> correspondingly
     xt_x_np /= xt_x_norm
     xt_y_np /= xt_x_norm
-    mask_np_init = np.ones((ic, 1))
+    mask_np_init = np.zeros((ic, 1))
     tf.logging.info('time elapsed: %.4f (s)' % (timer() - time_beg))
 
     # solve the LASSO problem

--- a/learners/channel_pruning_rmt/learner.py
+++ b/learners/channel_pruning_rmt/learner.py
@@ -536,6 +536,8 @@ class ChannelPrunedRmtLearner(AbstractLearner):  # pylint: disable=too-many-inst
         train_op = w_mat.assign_add(-lrn_rate * gacc1 / (tf.sqrt(gacc2) + epsilon))
       init_op = tf.variables_initializer([x_mat, y_mat, w_mat, gacc1, gacc2, train_step])
 
+      train_op = w_mat.assign(tf.linalg.lstsq(x_mat, y_mat, l2_regularizer=FLAGS.loss_w_dcy))
+
     # pack placeholders and variables into dict
     meta_lstsq = {
       'x_mat_ph': x_mat_ph,


### PR DESCRIPTION
In this PR, we slightly optimize the performance of `ChannelPrunedRmtLearner`, especially for SSD-VGG16 models. Below is a brief comparison against the previous PR #228:

Model: SSD-VGG-16
Uncompressed model's mAP: 77.64%

| Pruned Layers | Prune Ratio | FLOPs | mAP (PR #228) | mAP (This PR) |
|:-:|:-:|:-:|:-:|:-:|
| Backbone-only | 0.2 | 67.34% | 77.43% | 77.53% (+0.10%) |
| Backbone-only | 0.3 | 53.58% | 77.05% | 76.94% (-0.11%) |
| Backbone-only | 0.4 | 41.63% | 75.47% | 75.81% (+0.34%) |
| Backbone-only | 0.5 | 31.56% | 73.29% | 74.42% (+1.13%) |
| All layers | 0.2 | 66.50% | 76.98% | 77.22% (+0.24%) |
| All layers | 0.3 | 52.32% | 76.42% | 76.90% (+0.48%) |
| All layers | 0.4 | 39.96% | 74.89% | 75.80% (+0.91%) |
| All layers | 0.5 | 29.47% | 72.48% | 73.76% (+1.28%) |

P.R.: The usage is kept the same as that in PR #228.