### PR TITLE
Allow forward_train() to Use Ground-truth Labels

### DIFF
--- a/examples/convnet_at_fmnist.py
+++ b/examples/convnet_at_fmnist.py
@@ -69,11 +69,11 @@ def forward_fn(inputs, data_format):
 class ModelHelper(AbstractModelHelper):
   """Model helper for creating a ConvNet model for the Fashion-MNIST dataset."""
 
-  def __init__(self):
+  def __init__(self, data_format='channels_last'):
     """Constructor function."""
 
     # class-independent initialization
-    super(ModelHelper, self).__init__()
+    super(ModelHelper, self).__init__(data_format)
 
     # initialize training & evaluation subsets
     self.dataset_train = FMnistDataset(is_train=True)
@@ -89,15 +89,15 @@ class ModelHelper(AbstractModelHelper):
 
     return self.dataset_eval.build()
 
-  def forward_train(self, inputs, data_format='channels_last'):
+  def forward_train(self, inputs):
     """Forward computation at training."""
 
-    return forward_fn(inputs, data_format)
+    return forward_fn(inputs, self.data_format)
 
-  def forward_eval(self, inputs, data_format='channels_last'):
+  def forward_eval(self, inputs):
     """Forward computation at evaluation."""
 
-    return forward_fn(inputs, data_format)
+    return forward_fn(inputs, self.data_format)
 
   def calc_loss(self, labels, outputs, trainable_vars):
     """Calculate loss (and some extra evaluation metrics)."""

--- a/nets/abstract_model_helper.py
+++ b/nets/abstract_model_helper.py
@@ -30,12 +30,16 @@ class AbstractModelHelper(ABC):
   All functions marked with "@abstractmethod" must be explicitly implemented in the sub-class.
   """
 
-  def __init__(self):
+  def __init__(self, data_format='channels_last'):
     """Constructor function.
 
     Note: DO NOT create any TF operations here!!!
+
+    Args:
+    * data_format: data format ('channels_last' OR 'channels_first')
     """
-    pass
+
+    self.data_format = data_format
 
   @abstractmethod
   def build_dataset_train(self, enbl_trn_val_split):
@@ -62,12 +66,11 @@ class AbstractModelHelper(ABC):
     pass
 
   @abstractmethod
-  def forward_train(self, inputs, data_format):
+  def forward_train(self, inputs):
     """Forward computation at training.
 
     Args:
     * inputs: inputs to the network's forward pass
-    * data_format: data format ('channels_last' OR 'channels_first')
 
     Returns:
     * outputs: outputs from the network's forward pass
@@ -75,12 +78,11 @@ class AbstractModelHelper(ABC):
     pass
 
   @abstractmethod
-  def forward_eval(self, inputs, data_format):
+  def forward_eval(self, inputs):
     """Forward computation at evaluation.
 
     Args:
     * inputs: inputs to the network's forward pass
-    * data_format: data format ('channels_last' OR 'channels_first')
 
     Returns:
     * outputs: outputs from the network's forward pass

--- a/nets/abstract_model_helper.py
+++ b/nets/abstract_model_helper.py
@@ -30,7 +30,7 @@ class AbstractModelHelper(ABC):
   All functions marked with "@abstractmethod" must be explicitly implemented in the sub-class.
   """
 
-  def __init__(self, data_format='channels_last'):
+  def __init__(self, data_format):
     """Constructor function.
 
     Note: DO NOT create any TF operations here!!!

--- a/nets/abstract_model_helper.py
+++ b/nets/abstract_model_helper.py
@@ -66,11 +66,12 @@ class AbstractModelHelper(ABC):
     pass
 
   @abstractmethod
-  def forward_train(self, inputs):
+  def forward_train(self, inputs, labels=None):
     """Forward computation at training.
 
     Args:
     * inputs: inputs to the network's forward pass
+    * labels: ground-truth labels
 
     Returns:
     * outputs: outputs from the network's forward pass

--- a/nets/lenet_at_cifar10.py
+++ b/nets/lenet_at_cifar10.py
@@ -70,11 +70,11 @@ def forward_fn(inputs, data_format):
 class ModelHelper(AbstractModelHelper):
   """Model helper for creating a LeNet-like model for the CIFAR-10 dataset."""
 
-  def __init__(self):
+  def __init__(self, data_format='channels_last'):
     """Constructor function."""
 
     # class-independent initialization
-    super(ModelHelper, self).__init__()
+    super(ModelHelper, self).__init__(data_format)
 
     # initialize training & evaluation subsets
     self.dataset_train = Cifar10Dataset(is_train=True)
@@ -90,15 +90,15 @@ class ModelHelper(AbstractModelHelper):
 
     return self.dataset_eval.build()
 
-  def forward_train(self, inputs, data_format='channels_last'):
+  def forward_train(self, inputs):
     """Forward computation at training."""
 
-    return forward_fn(inputs, data_format)
+    return forward_fn(inputs, self.data_format)
 
-  def forward_eval(self, inputs, data_format='channels_last'):
+  def forward_eval(self, inputs):
     """Forward computation at evaluation."""
 
-    return forward_fn(inputs, data_format)
+    return forward_fn(inputs, self.data_format)
 
   def calc_loss(self, labels, outputs, trainable_vars):
     """Calculate loss (and some extra evaluation metrics)."""

--- a/nets/mobilenet_at_ilsvrc12.py
+++ b/nets/mobilenet_at_ilsvrc12.py
@@ -69,11 +69,12 @@ def forward_fn(inputs, is_train):
 class ModelHelper(AbstractModelHelper):
   """Model helper for creating a MobileNet model for the ILSVRC-12 dataset."""
 
-  def __init__(self):
+  def __init__(self, data_format='channels_last'):
     """Constructor function."""
 
     # class-independent initialization
-    super(ModelHelper, self).__init__()
+    assert data_format == 'channels_last', 'MobileNet only supports \'channels_last\' data format'
+    super(ModelHelper, self).__init__(data_format)
 
     # initialize training & evaluation subsets
     self.dataset_train = Ilsvrc12Dataset(is_train=True)
@@ -89,17 +90,13 @@ class ModelHelper(AbstractModelHelper):
 
     return self.dataset_eval.build()
 
-  def forward_train(self, inputs, data_format='channels_last'):
+  def forward_train(self, inputs):
     """Forward computation at training."""
-
-    assert data_format == 'channels_last', 'MobileNet only supports \'channels_last\' data format'
 
     return forward_fn(inputs, is_train=True)
 
-  def forward_eval(self, inputs, data_format='channels_last'):
+  def forward_eval(self, inputs):
     """Forward computation at evaluation."""
-
-    assert data_format == 'channels_last', 'MobileNet only supports \'channels_last\' data format'
 
     return forward_fn(inputs, is_train=False)
 

--- a/nets/resnet_at_cifar10.py
+++ b/nets/resnet_at_cifar10.py
@@ -68,11 +68,11 @@ def forward_fn(inputs, is_train, data_format):
 class ModelHelper(AbstractModelHelper):
   """Model helper for creating a ResNet model for the CIFAR-10 dataset."""
 
-  def __init__(self):
+  def __init__(self, data_format='channels_last'):
     """Constructor function."""
 
     # class-independent initialization
-    super(ModelHelper, self).__init__()
+    super(ModelHelper, self).__init__(data_format)
 
     # initialize training & evaluation subsets
     self.dataset_train = Cifar10Dataset(is_train=True)
@@ -88,15 +88,15 @@ class ModelHelper(AbstractModelHelper):
 
     return self.dataset_eval.build()
 
-  def forward_train(self, inputs, data_format='channels_last'):
+  def forward_train(self, inputs):
     """Forward computation at training."""
 
-    return forward_fn(inputs, is_train=True, data_format=data_format)
+    return forward_fn(inputs, is_train=True, data_format=self.data_format)
 
-  def forward_eval(self, inputs, data_format='channels_last'):
+  def forward_eval(self, inputs):
     """Forward computation at evaluation."""
 
-    return forward_fn(inputs, is_train=False, data_format=data_format)
+    return forward_fn(inputs, is_train=False, data_format=self.data_format)
 
   def calc_loss(self, labels, outputs, trainable_vars):
     """Calculate loss (and some extra evaluation metrics)."""

--- a/nets/resnet_at_ilsvrc12.py
+++ b/nets/resnet_at_ilsvrc12.py
@@ -96,11 +96,11 @@ def forward_fn(inputs, is_train, data_format):
 class ModelHelper(AbstractModelHelper):
   """Model helper for creating a ResNet model for the ILSVRC-12 dataset."""
 
-  def __init__(self):
+  def __init__(self, data_format='channels_last'):
     """Constructor function."""
 
     # class-independent initialization
-    super(ModelHelper, self).__init__()
+    super(ModelHelper, self).__init__(data_format)
 
     # initialize training & evaluation subsets
     self.dataset_train = Ilsvrc12Dataset(is_train=True)
@@ -116,15 +116,15 @@ class ModelHelper(AbstractModelHelper):
 
     return self.dataset_eval.build()
 
-  def forward_train(self, inputs, data_format='channels_last'):
+  def forward_train(self, inputs):
     """Forward computation at training."""
 
-    return forward_fn(inputs, is_train=True, data_format=data_format)
+    return forward_fn(inputs, is_train=True, data_format=self.data_format)
 
-  def forward_eval(self, inputs, data_format='channels_last'):
+  def forward_eval(self, inputs):
     """Forward computation at evaluation."""
 
-    return forward_fn(inputs, is_train=False, data_format=data_format)
+    return forward_fn(inputs, is_train=False, data_format=self.data_format)
 
   def calc_loss(self, labels, outputs, trainable_vars):
     """Calculate loss (and some extra evaluation metrics)."""

--- a/tools/conversion/convert_data_format.py
+++ b/tools/conversion/convert_data_format.py
@@ -33,7 +33,7 @@ tf.app.flags.DEFINE_boolean('enbl_multi_gpu', False, 'enable multi-GPU training'
 tf.app.flags.DEFINE_string('model_dir_in', './models', 'input model directory')
 tf.app.flags.DEFINE_string('model_dir_out', './models_out', 'output model directory')
 tf.app.flags.DEFINE_string('model_scope', 'model', 'model\'s variable scope name')
-tf.app.flags.DEFINE_string('data_format_src', 'channels_last', 'data format in the source model')
+tf.app.flags.DEFINE_string('data_format', 'channels_last', 'data format in the output model')
 
 def main(unused_argv):
   """Main entry.
@@ -50,7 +50,7 @@ def main(unused_argv):
     #sess = tf.Session()
 
     # create the model helper
-    model_helper = ModelHelper()
+    model_helper = ModelHelper(FLAGS.data_format)
     data_scope = 'data'
     model_scope = FLAGS.model_scope
 
@@ -63,11 +63,7 @@ def main(unused_argv):
 
       # model definition
       with tf.variable_scope(model_scope):
-        if FLAGS.data_format_src == 'channels_last':
-          data_format_dst = 'channels_first'
-        else:
-          data_format_dst = 'channels_last'
-        logits = model_helper.forward_eval(images, data_format=data_format_dst)
+        logits = model_helper.forward_eval(images)
 
       # add input & output tensors to certain collections
       tf.add_to_collection('images_final', images)


### PR DESCRIPTION
Some models (*e.g.* Faster R-CNN) may require ground-truth labels to be used during its forward pass in the training phase. Therefore, in this PR, we extend the function interface of `forward_train` in the `AbstractModelHelper` as below:
``` Python
# previous
def forward_train(self, inputs):

# current
def forward_train(self, inputs, labels=None):
```
For models that do not require ground-truth labels during its forward pass in the training phase, no changes is needed.

P.S.: in order to simplify the interface of `forward_train` and `forward_eval`, we have moved the specification of `data_format` to the constructor function. Its default value is still set to `channels_last`.