### PR TITLE
improve export_quant_tflite_model.py for generalization

### DIFF
--- a/docs/docs/uq_learner.md
+++ b/docs/docs/uq_learner.md
@@ -201,7 +201,7 @@ where `--nb_epochs_rat 0.2` specifies that only 20% training epochs to be used, 
 
 ```bash
 # load the checkpoints in ./models_uqtf_eval
-$ python export_quant_tflite_models.py \
+$ python tools/conversion/export_quant_tflite_models.py \
     --model_dir ./models_uqtf_eval \
     --enbl_post_quant
 ```


### PR DESCRIPTION
目前 `export_quant_tflite_model.py` 文件的quantization 系数是固定的，我测试 cifar resnet的时候发现不适用。我现在改成输入变量了。 